### PR TITLE
fix: file path for grepping version number in create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,7 +21,7 @@ jobs:
       - id: get-release-vars
         name: Configure Release Vars
         run: |
-          release_version=v$(grep -E "version = \"[0-9]+\.[0-9]+\.[0-9]+\"" pyproject.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+          release_version=v$(grep -E "version = \"[0-9]+\.[0-9]+\.[0-9]+\"" codecov-cli/pyproject.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
           previous_version=$(git tag --sort=-creatordate | head -n 2 | tail -n 1)
           echo "release_version=$release_version"
           echo "previous_version=$previous_version"


### PR DESCRIPTION
Missed this in the last pr, causing workflow to fail rip.