### PR TITLE
deploy: Enable real publishes to pypi and gcs

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,4 +12,5 @@ targets:
       - algorithm: sha256
     includeNames: /^(sentry-prevent-|sentry_prevent_|codecov|codecov_)cli.*/i
 
-  # - name: pypi
+  - name: pypi
+    includeNames: /sentry_prevent_cli-*/i

--- a/.github/workflows/release-codecov-cli.yml
+++ b/.github/workflows/release-codecov-cli.yml
@@ -3,38 +3,38 @@
 name: Build and publish codecov-cli
 
 on:
-  release:
-    types: [published]
+  push
+  # release:
+  #   types: [published]
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  publish_to_pypi:
+    permissions:
+      id-token: write # This is required for OIDC
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/codecov-cli
     steps:
-      - run: echo "hi from build and publish codecov-cli"
+      - name: Download pypi release assets
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          # tag: ${{ github.ref_name }}
+          tag: "v11.0.6"
+          fileName: codecov_cli-*
+          out-file-path: codecov-cli/dist
 
-  # publish_to_pypi:
-  #   permissions:
-  #     id-token: write # This is required for OIDC
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/codecov-cli
-  #   steps:
-  #     - name: Download build artifacts
-  #       uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
-  #       with:
-  #         branch: release/${{ github.ref }}
-  #         name: codecov-cli_wheel
-  #         path: codecov-cli/dist
-  #
-  #     - name: Publish package to PyPi
-  #       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-  #       with:
-  #         verbose: true
-  #         packages-dir: codecov-cli/dist
+      - name: test
+        run: ls -R codecov-cli/dist
+
+      # - name: Publish package to PyPi
+      #   uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      #   with:
+      #     verbose: true
+      #     packages-dir: codecov-cli/dist
 
   # publish_release:
   #   name: Publish release

--- a/.github/workflows/release-codecov-cli.yml
+++ b/.github/workflows/release-codecov-cli.yml
@@ -3,9 +3,8 @@
 name: Build and publish codecov-cli
 
 on:
-  push
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -15,45 +14,38 @@ jobs:
     permissions:
       id-token: write # This is required for OIDC
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/codecov-cli
     steps:
       - name: Download pypi release assets
         uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
-          # tag: ${{ github.ref_name }}
-          tag: "v11.0.6"
+          tag: ${{ github.ref_name }}
           fileName: codecov_cli-*
           out-file-path: codecov-cli/dist
 
-      - name: test
-        run: ls -R codecov-cli/dist
+      - name: Publish package to PyPi
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          verbose: true
+          packages-dir: codecov-cli/dist
 
-      # - name: Publish package to PyPi
-      #   uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-      #   with:
-      #     verbose: true
-      #     packages-dir: codecov-cli/dist
+  publish_release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1.0.0"
+        with:
+          create_credentials_file: "true"
+          workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
+          service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
 
-  # publish_release:
-  #   name: Publish release
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   steps:
-  #     - id: "auth"
-  #       name: "Authenticate to Google Cloud"
-  #       uses: "google-github-actions/auth@v1.0.0"
-  #       with:
-  #         create_credentials_file: "true"
-  #         workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
-  #         service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
-  #
-  #     # Publish the release tag to a Pub/Sub topic
-  #     - name: Publish a message to a Pub/Sub topic
-  #       env:
-  #         CLOUDSDK_CORE_PROJECT: ${{ secrets.GCLOUD_UPLOADER_PROJECT_ID }}
-  #       run: |
-  #         gcloud pubsub topics publish ${{ secrets.GCLOUD_UPLOADER_PUBSUB_TOPIC }} --message '{"release":"'"${{ github.ref_name }}"'", "latest":true}'
+      # Publish the release tag to a Pub/Sub topic
+      - name: Publish a message to a Pub/Sub topic
+        env:
+          CLOUDSDK_CORE_PROJECT: ${{ secrets.GCLOUD_UPLOADER_PROJECT_ID }}
+        run: |
+          gcloud pubsub topics publish ${{ secrets.GCLOUD_UPLOADER_PUBSUB_TOPIC }} --message '{"release":"'"${{ github.ref_name }}"'", "latest":true}'


### PR DESCRIPTION
Enables the real publishing steps for both prevent-cli and codecov-cli.
