### PR TITLE
feat: implement customizable URL paths for upload endpoints

### DIFF
--- a/codecov-cli/codecov_cli/commands/upload_coverage.py
+++ b/codecov-cli/codecov_cli/commands/upload_coverage.py
@@ -7,11 +7,15 @@ import sentry_sdk
 
 from codecov_cli.commands.commit import create_commit
 from codecov_cli.commands.report import create_report
-from codecov_cli.commands.upload import do_upload, global_upload_options
+from codecov_cli.commands.upload import (
+    DEFAULT_URL_PATHS,
+    do_upload,
+    global_upload_options,
+)
 from codecov_cli.helpers.args import get_cli_args
 from codecov_cli.helpers.options import global_options
+from codecov_cli.helpers.upload_type import ReportType, report_type_from_str
 from codecov_cli.opentelemetry import close_telem
-from codecov_cli.helpers.upload_type import report_type_from_str, ReportType
 from codecov_cli.services.upload_coverage import upload_coverage_logic
 from codecov_cli.types import CommandContext
 
@@ -83,11 +87,13 @@ def upload_coverage(
                 ci_adapter = ctx.obj.get("ci_adapter")
                 enterprise_url = ctx.obj.get("enterprise_url")
                 args = get_cli_args(ctx)
+                url_paths = ctx.obj.get("url_paths", DEFAULT_URL_PATHS)
                 ctx.invoke(
                     upload_coverage_logic,
                     cli_config,
                     versioning_system,
                     ci_adapter,
+                    url_paths=url_paths,
                     branch=branch,
                     build_code=build_code,
                     build_url=build_url,

--- a/codecov-cli/codecov_cli/services/upload/__init__.py
+++ b/codecov-cli/codecov_cli/services/upload/__init__.py
@@ -7,8 +7,8 @@ import click
 from codecov_cli.fallbacks import FallbackFieldEnum
 from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 from codecov_cli.helpers.request import log_warnings_and_errors_if_any
-from codecov_cli.helpers.versioning_systems import VersioningSystemInterface
 from codecov_cli.helpers.upload_type import ReportType
+from codecov_cli.helpers.versioning_systems import VersioningSystemInterface
 from codecov_cli.plugins import select_preparation_plugins
 from codecov_cli.services.upload.file_finder import select_file_finder
 from codecov_cli.services.upload.legacy_upload_sender import LegacyUploadSender
@@ -25,6 +25,7 @@ def do_upload_logic(
     cli_config: typing.Dict,
     versioning_system: VersioningSystemInterface,
     ci_adapter: CIAdapterBase,
+    url_paths: typing.Dict,
     upload_coverage: bool = False,
     *,
     args: dict = None,
@@ -141,6 +142,7 @@ def do_upload_logic(
             token=token,
             env_vars=env_vars,
             report_code=report_code,
+            url_paths=url_paths,
             report_type=report_type,
             name=name,
             branch=branch,

--- a/codecov-cli/codecov_cli/services/upload_coverage/__init__.py
+++ b/codecov-cli/codecov_cli/services/upload_coverage/__init__.py
@@ -2,15 +2,16 @@ import pathlib
 import typing
 
 from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
+from codecov_cli.helpers.upload_type import ReportType
 from codecov_cli.helpers.versioning_systems import VersioningSystemInterface
 from codecov_cli.services.upload import do_upload_logic
-from codecov_cli.helpers.upload_type import ReportType
 
 
 def upload_coverage_logic(
     cli_config: typing.Dict,
     versioning_system: VersioningSystemInterface,
     ci_adapter: CIAdapterBase,
+    url_paths: typing.Dict,
     *,
     branch: typing.Optional[str],
     build_code: typing.Optional[str],
@@ -53,6 +54,7 @@ def upload_coverage_logic(
         cli_config=cli_config,
         versioning_system=versioning_system,
         ci_adapter=ci_adapter,
+        url_paths=url_paths,
         upload_coverage=True,
         args=args,
         branch=branch,

--- a/codecov-cli/tests/helpers/test_upload_sender.py
+++ b/codecov-cli/tests/helpers/test_upload_sender.py
@@ -1,22 +1,23 @@
 import json
 import re
+from copy import deepcopy
 from pathlib import Path
 
-from copy import deepcopy
 import pytest
 import responses
 from responses import matchers
 
 from codecov_cli import __version__ as codecov_cli_version
+from codecov_cli.commands.upload import DEFAULT_URL_PATHS
 from codecov_cli.helpers.encoder import encode_slug
+from codecov_cli.helpers.upload_type import ReportType
 from codecov_cli.services.upload.upload_sender import UploadSender
 from codecov_cli.types import (
     UploadCollectionResult,
-    UploadCollectionResultFileFixer,
     UploadCollectionResultFile,
+    UploadCollectionResultFileFixer,
 )
 from tests.data import reports_examples
-from codecov_cli.helpers.upload_type import ReportType
 
 upload_collection = UploadCollectionResult(["1", "apple.py", "3"], [], [])
 random_token = "f359afb9-8a2a-42ab-a448-c3d267ff495b"
@@ -26,6 +27,7 @@ named_upload_data = {
     "report_type": ReportType.COVERAGE,
     "report_code": "report_code",
     "env_vars": {},
+    "url_paths": DEFAULT_URL_PATHS,
     "name": "name",
     "branch": "branch",
     "slug": "org/repo",
@@ -41,6 +43,7 @@ test_results_named_upload_data = {
     "report_type": ReportType.TEST_RESULTS,
     "report_code": "report_code",
     "env_vars": {},
+    "url_paths": DEFAULT_URL_PATHS,
     "name": "name",
     "branch": "branch",
     "slug": "org/repo",
@@ -351,7 +354,10 @@ class TestUploadSender(object):
         ]
 
         sending_result = UploadSender().send_upload_data(
-            upload_collection, random_sha, None, **named_upload_data
+            upload_collection,
+            random_sha,
+            None,
+            **named_upload_data,
         )
         assert sending_result.error is None
         assert sending_result.warnings == []
@@ -374,7 +380,10 @@ class TestUploadSender(object):
         self, mocked_responses, mocked_legacy_upload_endpoint, mocked_storage_server
     ):
         sending_result = UploadSender().send_upload_data(
-            upload_collection, random_sha, random_token, **named_upload_data
+            upload_collection,
+            random_sha,
+            random_token,
+            **named_upload_data,
         )
         assert sending_result.error is None
         assert sending_result.warnings == []
@@ -388,7 +397,10 @@ class TestUploadSender(object):
         self, mocked_responses, mocked_legacy_upload_endpoint, mocked_storage_server
     ):
         sender = UploadSender().send_upload_data(
-            upload_collection, random_sha, random_token, **named_upload_data
+            upload_collection,
+            random_sha,
+            random_token,
+            **named_upload_data,
         )
 
         # default status for both put and post is 200
@@ -402,7 +414,10 @@ class TestUploadSender(object):
         mocked_legacy_upload_endpoint.status = 400
 
         sender = UploadSender().send_upload_data(
-            upload_collection, random_sha, random_token, **named_upload_data
+            upload_collection,
+            random_sha,
+            random_token,
+            **named_upload_data,
         )
 
         assert len(mocked_responses.calls) == 1
@@ -439,7 +454,10 @@ class TestUploadSender(object):
         mocked_storage_server.status = 400
 
         sender = UploadSender().send_upload_data(
-            upload_collection, random_sha, random_token, **named_upload_data
+            upload_collection,
+            random_sha,
+            random_token,
+            **named_upload_data,
         )
 
         assert len(mocked_responses.calls) == 2
@@ -455,7 +473,10 @@ class TestUploadSender(object):
         mocked_legacy_upload_endpoint.status = 400
 
         sender = UploadSender().send_upload_data(
-            upload_collection, random_sha, random_token, **named_upload_data
+            upload_collection,
+            random_sha,
+            random_token,
+            **named_upload_data,
         )
 
         assert sender.error is not None

--- a/codecov-cli/tests/services/upload/test_upload_service.py
+++ b/codecov-cli/tests/services/upload/test_upload_service.py
@@ -2,6 +2,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from codecov_cli.commands.upload import DEFAULT_URL_PATHS
 from codecov_cli.helpers.upload_type import ReportType
 from codecov_cli.services.upload import (
     LegacyUploadSender,
@@ -48,6 +49,7 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             report_type=ReportType.COVERAGE,
             commit_sha="commit_sha",
             report_code="report_code",
@@ -116,6 +118,7 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
         token="token",
         env_vars=None,
         report_code="report_code",
+        url_paths=DEFAULT_URL_PATHS,
         report_type=ReportType.COVERAGE,
         name="name",
         branch="branch",
@@ -165,6 +168,7 @@ def test_do_upload_logic_happy_path(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             report_type=ReportType.COVERAGE,
             commit_sha="commit_sha",
             report_code="report_code",
@@ -231,6 +235,7 @@ def test_do_upload_logic_happy_path(mocker):
         token="token",
         env_vars=None,
         report_code="report_code",
+        url_paths=DEFAULT_URL_PATHS,
         report_type=ReportType.COVERAGE,
         name="name",
         branch="branch",
@@ -276,6 +281,7 @@ def test_do_upload_logic_dry_run(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             report_type=ReportType.COVERAGE,
             commit_sha="commit_sha",
             report_code="report_code",
@@ -362,6 +368,7 @@ def test_do_upload_logic_verbose(mocker, use_verbose_option):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             branch="branch",
             build_code="build_code",
             build_url="build_url",
@@ -444,6 +451,7 @@ def test_do_upload_no_cov_reports_found(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             report_type=ReportType.COVERAGE,
             commit_sha="commit_sha",
             report_code="report_code",
@@ -550,6 +558,7 @@ def test_do_upload_rase_no_cov_reports_found_error(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            DEFAULT_URL_PATHS,
             report_type=ReportType.COVERAGE,
             commit_sha="commit_sha",
             report_code="report_code",
@@ -640,6 +649,7 @@ def test_do_upload_logic_happy_path_test_results(mocker):
             cli_config,
             versioning_system,
             ci_adapter,
+            url_paths={ReportType.TEST_RESULTS: "upload/test_results/v1"},
             args={"args": "fake_args"},
             branch="branch",
             build_code="build_code",
@@ -694,6 +704,7 @@ def test_do_upload_logic_happy_path_test_results(mocker):
         commit_sha="commit_sha",
         token="token",
         env_vars=None,
+        url_paths={ReportType.TEST_RESULTS: "upload/test_results/v1"},
         report_code="report_code",
         report_type=ReportType.TEST_RESULTS,
         name="name",

--- a/prevent-cli/src/prevent_cli/main.py
+++ b/prevent-cli/src/prevent_cli/main.py
@@ -14,12 +14,13 @@ from codecov_cli.commands.get_report_results import get_report_results
 from codecov_cli.commands.process_test_results import process_test_results
 from codecov_cli.commands.report import create_report
 from codecov_cli.commands.send_notifications import send_notifications
-from codecov_cli.commands.upload import do_upload
+from codecov_cli.commands.upload import DEFAULT_URL_PATHS, do_upload
 from codecov_cli.commands.upload_coverage import upload_coverage
 from codecov_cli.commands.upload_process import upload_process
 from codecov_cli.helpers.ci_adapters import get_ci_adapter, get_ci_providers_list
 from codecov_cli.helpers.config import load_cli_config
 from codecov_cli.helpers.logging_utils import configure_logger
+from codecov_cli.helpers.upload_type import ReportType
 from codecov_cli.helpers.versioning_systems import get_versioning_system
 from codecov_cli.opentelemetry import init_telem
 
@@ -83,6 +84,10 @@ def cli(
     ctx.obj["disable_telem"] = disable_telem
     ctx.obj["branding"] = branding
 
+    custom_url_paths = deepcopy(DEFAULT_URL_PATHS)
+    custom_url_paths[ReportType.TEST_RESULTS] = "/upload/test_analytics/v1"
+    ctx.obj["url_paths"] = custom_url_paths
+
     init_telem(ctx.obj)
 
 
@@ -100,18 +105,18 @@ for i, param in enumerate(upload.params):
         break
 
 
+cli.add_command(pr_base_picking)
+cli.add_command(empty_upload)
+cli.add_command(upload)
+cli.add_command(send_notifications)
+
+# deprecated commands:
 cli.add_command(do_upload)
 cli.add_command(create_commit)
 cli.add_command(create_report)
-cli.add_command(pr_base_picking)
-cli.add_command(empty_upload)
 cli.add_command(upload_coverage)
-cli.add_command(upload)
 cli.add_command(upload_process)
-cli.add_command(send_notifications)
 cli.add_command(process_test_results)
-
-# deprecated commands:
 cli.add_command(create_report_results)
 cli.add_command(get_report_results)
 


### PR DESCRIPTION
This enables downstream projects like prevent-cli to customize upload endpoint
URLs by setting url_paths in the Click context object.
    
- Add DEFAULT_URL_PATHS constant in upload.py with configurable URL templates
- Pass url_paths from command context through do_upload_logic to UploadSender
- Support different URL paths for COVERAGE and TEST_RESULTS upload types
- Update prevent-cli main.py to customize TEST_RESULTS path to test_analytics