### PR TITLE
Remove pytest-asyncio from dev dependencies

### DIFF
--- a/codecov-cli/pyproject.toml
+++ b/codecov-cli/pyproject.toml
@@ -25,7 +25,6 @@ dev = [
     "pre-commit==3.*",
     "pyinstaller==6.*",
     "pytest==7.*",
-    "pytest-asyncio==0.21.1",
     "pytest-cov==4.*",
     "pytest-env==1.*",
     "pytest-mock==3.*",


### PR DESCRIPTION
I suspect that its unused. Let's see if the CI agrees.