### PR TITLE
feat: Use job for GHA CLI workflow name

### DIFF
--- a/codecov-cli/codecov_cli/commands/upload.py
+++ b/codecov-cli/codecov_cli/commands/upload.py
@@ -111,7 +111,10 @@ _global_upload_options = [
         "--name",
         help="Custom defined name of the upload. Visible in Codecov UI",
         cls=CodecovOption,
-        fallback_field=FallbackFieldEnum.build_code,
+        fallback_fields=(
+            FallbackFieldEnum.job_name,
+            FallbackFieldEnum.build_code,
+        ),
     ),
     click.option(
         "-B",

--- a/codecov-cli/codecov_cli/fallbacks.py
+++ b/codecov-cli/codecov_cli/fallbacks.py
@@ -14,11 +14,21 @@ class FallbackFieldEnum(Enum):
     pull_request_number = auto()
     service = auto()
     slug = auto()
+    job_name = auto()
 
 
 class CodecovOption(click.Option):
+    fallback_fields: typing.Optional[tuple[FallbackFieldEnum, ...]]
+
     def __init__(self, *args, **kwargs):
-        self.fallback_field = kwargs.pop("fallback_field", None)
+        fallback_fields = kwargs.pop("fallback_fields", None)
+        fallback_field = kwargs.pop("fallback_field", None)
+        if fallback_fields is not None:
+            self.fallback_fields = tuple(fallback_fields)
+        elif fallback_field is not None:
+            self.fallback_fields = (fallback_field,)
+        else:
+            self.fallback_fields = None
         super().__init__(*args, **kwargs)
 
     def get_default(
@@ -27,17 +37,16 @@ class CodecovOption(click.Option):
         res = super().get_default(ctx, call=call)
         if res is not None:
             return res
-        if self.fallback_field is not None:
-            if ctx.obj.get("ci_adapter") is not None:
-                res = ctx.obj.get("ci_adapter").get_fallback_value(self.fallback_field)
-                if res is not None:
-                    return res
-            if ctx.obj.get("versioning_system") is not None:
-                res = ctx.obj.get("versioning_system").get_fallback_value(
-                    self.fallback_field
-                )
-                if res is not None:
-                    return res
+        if self.fallback_fields is not None:
+            for field in self.fallback_fields:
+                if ctx.obj.get("ci_adapter") is not None:
+                    res = ctx.obj.get("ci_adapter").get_fallback_value(field)
+                    if res is not None:
+                        return res
+                if ctx.obj.get("versioning_system") is not None:
+                    res = ctx.obj.get("versioning_system").get_fallback_value(field)
+                    if res is not None:
+                        return res
         return None
 
 

--- a/codecov-cli/codecov_cli/fallbacks.py
+++ b/codecov-cli/codecov_cli/fallbacks.py
@@ -17,7 +17,6 @@ class FallbackFieldEnum(Enum):
     job_name = auto()
 
 
-# Only these may be resolved from git; all other FallbackFieldEnum values are CI-only.
 _FIELDS_WITH_VERSIONING_FALLBACK = frozenset(
     {
         FallbackFieldEnum.branch,

--- a/codecov-cli/codecov_cli/fallbacks.py
+++ b/codecov-cli/codecov_cli/fallbacks.py
@@ -17,6 +17,17 @@ class FallbackFieldEnum(Enum):
     job_name = auto()
 
 
+# Only these may be resolved from git; all other FallbackFieldEnum values are CI-only.
+_FIELDS_WITH_VERSIONING_FALLBACK = frozenset(
+    {
+        FallbackFieldEnum.branch,
+        FallbackFieldEnum.commit_sha,
+        FallbackFieldEnum.slug,
+        FallbackFieldEnum.git_service,
+    }
+)
+
+
 class CodecovOption(click.Option):
     fallback_fields: typing.Optional[tuple[FallbackFieldEnum, ...]]
 
@@ -43,7 +54,10 @@ class CodecovOption(click.Option):
                     res = ctx.obj.get("ci_adapter").get_fallback_value(field)
                     if res is not None:
                         return res
-                if ctx.obj.get("versioning_system") is not None:
+                if (
+                    ctx.obj.get("versioning_system") is not None
+                    and field in _FIELDS_WITH_VERSIONING_FALLBACK
+                ):
                     res = ctx.obj.get("versioning_system").get_fallback_value(field)
                     if res is not None:
                         return res

--- a/codecov-cli/codecov_cli/helpers/ci_adapters/base.py
+++ b/codecov-cli/codecov_cli/helpers/ci_adapters/base.py
@@ -17,6 +17,7 @@ class CIAdapterBase(ABC):
             FallbackFieldEnum.pull_request_number: self._get_pull_request_number,
             FallbackFieldEnum.job_code: self._get_job_code,
             FallbackFieldEnum.git_service: self._get_git_service,
+            FallbackFieldEnum.job_name: self._get_job_name,
         }
 
     def get_fallback_value(
@@ -99,4 +100,11 @@ class CIAdapterBase(ABC):
         raise NotImplementedError("`get_service_name()` must be implemented.")
 
     def _get_git_service(self):
+        return None
+
+    def _get_job_name(self):
+        """
+        Name of the job that gets displayed in the Codecov UI
+        Returns: string
+        """
         return None

--- a/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -89,4 +89,8 @@ class GithubActionsCIAdapter(CIAdapterBase):
         return "GithubActions"
 
     def _get_job_name(self):
-        return os.getenv("GITHUB_JOB")
+        github_workflow = os.getenv("GITHUB_WORKFLOW")
+        github_job = os.getenv("GITHUB_JOB")
+        if github_workflow and github_job:
+            return f"{github_workflow} - {github_job}"
+        return github_workflow or github_job or None

--- a/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov-cli/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -87,3 +87,6 @@ class GithubActionsCIAdapter(CIAdapterBase):
 
     def get_service_name(self):
         return "GithubActions"
+
+    def _get_job_name(self):
+        return os.getenv("GITHUB_JOB")

--- a/codecov-cli/tests/factory.py
+++ b/codecov-cli/tests/factory.py
@@ -21,6 +21,7 @@ class FakeProvider(CIAdapterBase):
             FallbackFieldEnum.service: "FAKE_PROVIDER",
             FallbackFieldEnum.pull_request_number: "PR_NUMBER",
             FallbackFieldEnum.job_code: "JOB_CODE",
+            FallbackFieldEnum.job_name: None,
             FallbackFieldEnum.git_service: "FAKE_PROVIDER",
         }
         final_values = {**default_values, **values_dict}
@@ -52,6 +53,9 @@ class FakeProvider(CIAdapterBase):
 
     def _get_job_code(self):
         return self.values_dict[FallbackFieldEnum.job_code]
+
+    def _get_job_name(self):
+        return self.values_dict.get(FallbackFieldEnum.job_name)
 
     def get_service_name(self):
         return self.values_dict[FallbackFieldEnum.git_service]

--- a/codecov-cli/tests/test_fallbacks.py
+++ b/codecov-cli/tests/test_fallbacks.py
@@ -1,9 +1,9 @@
 import click
-
-from codecov_cli.fallbacks import BrandedOption
-from codecov_cli.branding import Branding
-
 from click.testing import CliRunner
+from unittest.mock import MagicMock
+
+from codecov_cli.branding import Branding
+from codecov_cli.fallbacks import BrandedOption, CodecovOption, FallbackFieldEnum
 
 
 @click.group()
@@ -31,3 +31,63 @@ def test_branded_option():
 
     result = runner.invoke(cli, ["hello-world"])
     assert result.output == "None\n"
+
+
+@click.group()
+def codecov_cli_group():
+    pass
+
+
+@codecov_cli_group.command()
+@click.option(
+    "--name",
+    cls=CodecovOption,
+    fallback_fields=(
+        FallbackFieldEnum.job_name,
+        FallbackFieldEnum.build_code,
+    ),
+)
+def with_name_fallback(name):
+    click.echo(name or "")
+
+
+def test_codecov_option_fallback_fields_uses_second_when_first_is_none():
+    runner = CliRunner()
+    adapter = MagicMock()
+
+    def get_fallback(field):
+        return {
+            FallbackFieldEnum.job_name: None,
+            FallbackFieldEnum.build_code: "build-42",
+        }[field]
+
+    adapter.get_fallback_value.side_effect = get_fallback
+
+    result = runner.invoke(
+        codecov_cli_group,
+        ["with-name-fallback"],
+        obj={"ci_adapter": adapter, "versioning_system": None},
+    )
+    assert result.exit_code == 0
+    assert result.output == "build-42\n"
+
+
+def test_codecov_option_fallback_fields_prefers_first_when_set():
+    runner = CliRunner()
+    adapter = MagicMock()
+
+    def get_fallback(field):
+        return {
+            FallbackFieldEnum.job_name: "my-job",
+            FallbackFieldEnum.build_code: "build-42",
+        }[field]
+
+    adapter.get_fallback_value.side_effect = get_fallback
+
+    result = runner.invoke(
+        codecov_cli_group,
+        ["with-name-fallback"],
+        obj={"ci_adapter": adapter, "versioning_system": None},
+    )
+    assert result.exit_code == 0
+    assert result.output == "my-job\n"


### PR DESCRIPTION
Closes https://github.com/codecov/core-engineering/issues/32

- adds a new fallback field `job_name`
- adds a new `fallback_fields` argument to take multiple fields in a chain with precedence
- uses GHA `GITHUB_JOB` and `GITHUB_WORKFLOW` as job_name first fallback before using job_code

Uses the YAML job name as the first level of fallback for name before currently used `build_code` from GHA. This built in env does **NOT** use the "name" field for the job even if it is set by the user. This also does **NOT** have any info on the current matrix value. As a future option, we could possibly ask users to provide the matrix value through their YAML file with a `with` statement like:
```
        with:
          matrix: ${{ toJSON(matrix) }}
```