### PR TITLE
feat: Send upload size to upload request and cli version with API req…

### DIFF
--- a/codecov-cli/codecov_cli/services/commit/__init__.py
+++ b/codecov-cli/codecov_cli/services/commit/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import typing
 
+from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import CODECOV_INGEST_URL
 from codecov_cli.helpers.encoder import encode_slug
 from codecov_cli.helpers.request import (
@@ -75,6 +76,7 @@ def send_commit_data(
         "commitid": commit_sha,
         "parent_commit_id": parent_sha,
         "pullid": pr,
+        "version": codecov_cli_version,
     }
 
     upload_url = enterprise_url or CODECOV_INGEST_URL

--- a/codecov-cli/codecov_cli/services/empty_upload/__init__.py
+++ b/codecov-cli/codecov_cli/services/empty_upload/__init__.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import CODECOV_API_URL
 from codecov_cli.helpers.encoder import encode_slug
 from codecov_cli.helpers.request import (
@@ -32,6 +33,7 @@ def empty_upload_logic(
         data={
             "cli_args": args,
             "should_force": should_force,
+            "version": codecov_cli_version,
         },
     )
     log_warnings_and_errors_if_any(sending_result, "Empty Upload", fail_on_error)

--- a/codecov-cli/codecov_cli/services/report/__init__.py
+++ b/codecov-cli/codecov_cli/services/report/__init__.py
@@ -3,8 +3,7 @@ import logging
 import time
 import typing
 
-import requests
-
+from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers import request
 from codecov_cli.helpers.config import CODECOV_API_URL, CODECOV_INGEST_URL
 from codecov_cli.helpers.encoder import encode_slug
@@ -58,6 +57,7 @@ def send_create_report_request(
     data = {
         "cli_args": args,
         "code": code,
+        "version": codecov_cli_version,
     }
     headers = get_token_header(token)
     upload_url = enterprise_url or CODECOV_INGEST_URL
@@ -103,6 +103,7 @@ def send_reports_result_request(
 ):
     data = {
         "cli_args": args,
+        "version": codecov_cli_version,
     }
     headers = get_token_header(token)
     upload_url = enterprise_url or CODECOV_API_URL

--- a/codecov-cli/codecov_cli/services/upload/upload_sender.py
+++ b/codecov-cli/codecov_cli/services/upload/upload_sender.py
@@ -2,7 +2,6 @@ import base64
 import json
 import logging
 import typing
-import sys
 import zlib
 from typing import Any, Dict
 
@@ -97,6 +96,8 @@ class UploadSender(object):
                 reports_payload = self._generate_payload(
                     upload_data, env_vars, report_type
                 )
+                reports_payload_size = len(reports_payload)
+                data["report_payload_bytes"] = reports_payload_size
 
             with sentry_sdk.start_span(name="upload_sender_storage_request"):
                 logger.debug("Sending upload request to Codecov")
@@ -126,9 +127,8 @@ class UploadSender(object):
                 put_url = resp_json_obj["raw_upload_location"]
 
             with sentry_sdk.start_span(name="upload_sender_storage") as storage_span:
-                payload_size = sys.getsizeof(reports_payload)
-                storage_span.set_data("payload_size", payload_size)
-                logger.info(f"Sending upload ({payload_size} bytes) to storage")
+                storage_span.set_data("payload_size", reports_payload_size)
+                logger.info(f"Sending upload ({reports_payload_size} bytes) to storage")
                 resp_from_storage = send_put_request(put_url, data=reports_payload)
 
             return resp_from_storage

--- a/codecov-cli/codecov_cli/services/upload/upload_sender.py
+++ b/codecov-cli/codecov_cli/services/upload/upload_sender.py
@@ -91,6 +91,7 @@ class UploadSender(object):
                     commit_sha,
                     report_code,
                     upload_coverage,
+                    file_not_found=file_not_found,
                 )
                 # Data that goes to storage
                 reports_payload = self._generate_payload(

--- a/codecov-cli/codecov_cli/services/upload_completion/__init__.py
+++ b/codecov-cli/codecov_cli/services/upload_completion/__init__.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import CODECOV_API_URL
 from codecov_cli.helpers.encoder import encode_slug
 from codecov_cli.helpers.request import (
@@ -27,6 +28,7 @@ def upload_completion_logic(
     url = f"{upload_url}/upload/{git_service}/{encoded_slug}/commits/{commit_sha}/upload-complete"
     data = {
         "cli_args": args,
+        "version": codecov_cli_version,
     }
     sending_result = send_post_request(url=url, data=data, headers=headers)
     log_warnings_and_errors_if_any(

--- a/codecov-cli/tests/helpers/test_upload_sender.py
+++ b/codecov-cli/tests/helpers/test_upload_sender.py
@@ -80,11 +80,11 @@ request_data = {
 }
 
 
-def _test_results_ingest_post_json(upload_data: UploadCollectionResult) -> dict:
-    # get_url_and_possibly_update_data always sets data["file_not_found"] from its
-    # default (False), overwriting the value set earlier when no test files exist.
+def _test_results_ingest_post_json(
+    upload_data: UploadCollectionResult, *, file_not_found: bool
+) -> dict:
     return {
-        **_upload_ingest_post_json_base(file_not_found=False),
+        **_upload_ingest_post_json_base(file_not_found=file_not_found),
         "slug": encode_slug("org/repo"),
         "branch": "branch",
         "commit": random_sha,
@@ -307,7 +307,9 @@ class TestUploadSender(object):
 
         mocked_test_results_endpoint.match = [
             matchers.json_params_matcher(
-                _test_results_ingest_post_json(ta_upload_collection)
+                _test_results_ingest_post_json(
+                    ta_upload_collection, file_not_found=False
+                )
             ),
             matchers.header_matcher(headers),
         ]
@@ -343,7 +345,9 @@ class TestUploadSender(object):
     ):
         headers = {"Authorization": f"token {random_token}"}
 
-        req_data = _test_results_ingest_post_json(upload_collection)
+        req_data = _test_results_ingest_post_json(
+            upload_collection, file_not_found=True
+        )
 
         mocked_test_results_endpoint_file_not_found.match = [
             matchers.json_params_matcher(req_data),

--- a/codecov-cli/tests/helpers/test_upload_sender.py
+++ b/codecov-cli/tests/helpers/test_upload_sender.py
@@ -52,17 +52,49 @@ test_results_named_upload_data = {
     "ci_service": "ci_service",
     "git_service": "github",
 }
+
+
+def _upload_ingest_post_json_base(*, file_not_found: bool) -> dict:
+    return {
+        "ci_service": "ci_service",
+        "ci_url": "build_url",
+        "cli_args": None,
+        "env": {},
+        "flags": "flags",
+        "job_code": "job_code",
+        "name": "name",
+        "version": codecov_cli_version,
+        "file_not_found": file_not_found,
+    }
+
+
+_report_payload_bytes_coverage = len(
+    UploadSender()._generate_payload(
+        upload_collection, {}, ReportType.COVERAGE
+    )
+)
+
 request_data = {
-    "ci_service": "ci_service",
-    "ci_url": "build_url",
-    "cli_args": None,
-    "env": {},
-    "flags": "flags",
-    "job_code": "job_code",
-    "name": "name",
-    "version": codecov_cli_version,
-    "file_not_found": False,
+    **_upload_ingest_post_json_base(file_not_found=False),
+    "report_payload_bytes": _report_payload_bytes_coverage,
 }
+
+
+def _test_results_ingest_post_json(upload_data: UploadCollectionResult) -> dict:
+    # get_url_and_possibly_update_data always sets data["file_not_found"] from its
+    # default (False), overwriting the value set earlier when no test files exist.
+    return {
+        **_upload_ingest_post_json_base(file_not_found=False),
+        "slug": encode_slug("org/repo"),
+        "branch": "branch",
+        "commit": random_sha,
+        "service": "github",
+        "report_payload_bytes": len(
+            UploadSender()._generate_payload(
+                upload_data, {}, ReportType.TEST_RESULTS
+            )
+        ),
+    }
 
 
 @pytest.fixture
@@ -266,17 +298,19 @@ class TestUploadSender(object):
     ):
         headers = {"Authorization": f"token {random_token}"}
 
-        mocked_legacy_upload_endpoint.match = [
-            matchers.json_params_matcher(request_data),
-            matchers.header_matcher(headers),
-        ]
-
         ta_upload_collection = deepcopy(upload_collection)
 
         test_path = tmp_path / "test_results.xml"
         test_path.write_bytes(b"test_data")
 
         ta_upload_collection.files = [UploadCollectionResultFile(test_path)]
+
+        mocked_test_results_endpoint.match = [
+            matchers.json_params_matcher(
+                _test_results_ingest_post_json(ta_upload_collection)
+            ),
+            matchers.header_matcher(headers),
+        ]
 
         sending_result = UploadSender().send_upload_data(
             ta_upload_collection,
@@ -309,10 +343,9 @@ class TestUploadSender(object):
     ):
         headers = {"Authorization": f"token {random_token}"}
 
-        req_data = deepcopy(request_data)
-        req_data["file_not_found"] = True
+        req_data = _test_results_ingest_post_json(upload_collection)
 
-        mocked_legacy_upload_endpoint.match = [
+        mocked_test_results_endpoint_file_not_found.match = [
             matchers.json_params_matcher(req_data),
             matchers.header_matcher(headers),
         ]

--- a/codecov-cli/tests/services/commit/test_commit_service.py
+++ b/codecov-cli/tests/services/commit/test_commit_service.py
@@ -2,6 +2,7 @@ import uuid
 
 from click.testing import CliRunner
 
+from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.services.commit import create_commit_logic, send_commit_data
 from codecov_cli.types import RequestError, RequestResult, RequestResultWarning
 from tests.test_helpers import parse_outstreams_into_log_lines
@@ -171,6 +172,7 @@ def test_commit_sender_with_forked_repo(mocker):
             "commitid": "commit_sha",
             "parent_commit_id": "parent_sha",
             "pullid": "1",
+            "version": codecov_cli_version,
         },
         headers=None,
     )
@@ -201,6 +203,7 @@ def test_commit_without_token(mocker):
             "commitid": "commit_sha",
             "parent_commit_id": "parent_sha",
             "pullid": "1",
+            "version": codecov_cli_version,
         },
         headers=None,
     )
@@ -232,6 +235,7 @@ def test_commit_sender_with_forked_repo_bad_branch(mocker):
             "commitid": "commit_sha",
             "parent_commit_id": "parent_sha",
             "pullid": "1",
+            "version": codecov_cli_version,
         },
         headers=None,
     )


### PR DESCRIPTION
…uests

Closes https://github.com/codecov/core-engineering/issues/31

- Changes upload size calculation from `sys.getsizeof()` to `len()` as len more accurately represents the bytes' size while getsizeof includes Python overhead in its memory size.
- Include Codecov CLI version in the data for all post requests
- Send through correct `file_not_found` data attribute